### PR TITLE
Built in check for not defined expandedkeys

### DIFF
--- a/lib/Tree.js
+++ b/lib/Tree.js
@@ -644,7 +644,9 @@ var Tree = function (_React$Component) {
 
       // expand
       if (val.expand && expandedKeys.indexOf(key) === -1) {
-        return expandedKeys.concat([key]);
+        expandedKeys = expandedKeys.concat([key]);
+        this.props.onExpand(expandedKeys, { node: treeNode });
+        return expandedKeys;
       }
 
       return null;
@@ -832,7 +834,8 @@ Tree.propTypes = {
   openTransitionName: _react.PropTypes.string,
   openAnimation: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.object]),
   dragExpandDelay: _react.PropTypes.number,
-  dropGapSize: _react.PropTypes.number
+  dropGapSize: _react.PropTypes.number,
+  externalDragMode: _react.PropTypes.object
 };
 
 Tree.defaultProps = {

--- a/lib/Tree.js
+++ b/lib/Tree.js
@@ -65,7 +65,7 @@ var Tree = function (_React$Component) {
   function Tree(props) {
     (0, _classCallCheck3.default)(this, Tree);
 
-    var _this = (0, _possibleConstructorReturn3.default)(this, (0, _getPrototypeOf2.default)(Tree).call(this, props));
+    var _this = (0, _possibleConstructorReturn3.default)(this, (Tree.__proto__ || (0, _getPrototypeOf2.default)(Tree)).call(this, props));
 
     ['onKeyDown', 'onCheck'].forEach(function (m) {
       _this[m] = _this[m].bind(_this);
@@ -94,6 +94,12 @@ var Tree = function (_React$Component) {
       var checkedKeys = this.getDefaultCheckedKeys(nextProps, true);
       var selectedKeys = this.getDefaultSelectedKeys(nextProps, true);
       var st = {};
+
+      if (nextProps.externalDragMode) {
+        this.dragNodesKeys = nextProps.externalDragMode.externalDragNodeKeys;
+        this.dragNode = nextProps.externalDragMode.externalDragNode;
+      }
+
       if (expandedKeys) {
         st.expandedKeys = expandedKeys;
       }
@@ -135,7 +141,8 @@ var Tree = function (_React$Component) {
 
       this.props.onDragStart({
         event: e,
-        node: treeNode
+        node: treeNode,
+        nodeKeys: this.dragNodesKeys
       });
 
       this._dropTrigger = false;
@@ -202,6 +209,9 @@ var Tree = function (_React$Component) {
 
       this.stopDragEnterTimeout(treeNode.props.eventKey);
       this.props.onDragLeave({ event: e, node: treeNode });
+      this.setState({
+        dragOverNodeKey: ''
+      });
     }
   }, {
     key: 'onDragEnd',
@@ -266,9 +276,21 @@ var Tree = function (_React$Component) {
         });
       }
 
+      // Adjust dropPosition
+      var index = res.dropPosition + (res.dropPositionOnNode > 0 ? 1 : 0);
+
+      if (res.isSameLevel && res.dragPosition < res.dropPosition) {
+        index -= 1;
+      }
+      res.dropPosition = index;
+
       // restore expanded keys
       if ('expandedKeys' in this.props) {
-        res.rawExpandedKeys = [].concat((0, _toConsumableArray3.default)(this._rawExpandedKeys)) || [].concat((0, _toConsumableArray3.default)(this.state.expandedKeys));
+        if (this._rawExpandedKeys) {
+          res.rawExpandedKeys = [].concat((0, _toConsumableArray3.default)(this._rawExpandedKeys));
+        } else {
+          res.rawExpandedKeys = [].concat((0, _toConsumableArray3.default)(this.state.expandedKeys));
+        }
       }
 
       this.props.onDrop(res);
@@ -349,16 +371,14 @@ var Tree = function (_React$Component) {
         this.props.onCheck((0, _util.getStrictlyValue)(checkedKeys, this.props.checkedKeys.halfChecked), newSt);
       } else {
         if (checked && index === -1) {
-          (function () {
-            _this5.treeNodesStates[treeNode.props.pos].checked = true;
-            var checkedPositions = [];
-            (0, _keys2.default)(_this5.treeNodesStates).forEach(function (i) {
-              if (_this5.treeNodesStates[i].checked) {
-                checkedPositions.push(i);
-              }
-            });
-            (0, _util.handleCheckState)(_this5.treeNodesStates, (0, _util.filterParentPosition)(checkedPositions), true);
-          })();
+          this.treeNodesStates[treeNode.props.pos].checked = true;
+          var checkedPositions = [];
+          (0, _keys2.default)(this.treeNodesStates).forEach(function (i) {
+            if (_this5.treeNodesStates[i].checked) {
+              checkedPositions.push(i);
+            }
+          });
+          (0, _util.handleCheckState)(this.treeNodesStates, (0, _util.filterParentPosition)(checkedPositions), true);
         }
         if (!checked) {
           this.treeNodesStates[treeNode.props.pos].checked = false;
@@ -641,7 +661,7 @@ var Tree = function (_React$Component) {
   }, {
     key: 'renderTreeNode',
     value: function renderTreeNode(child, index) {
-      var level = arguments.length <= 2 || arguments[2] === undefined ? 0 : arguments[2];
+      var level = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
 
       var pos = level + '-' + index;
       var key = child.key || pos;
@@ -733,37 +753,33 @@ var Tree = function (_React$Component) {
           this.halfCheckedKeys = props._treeNodesStates.halfCheckedKeys;
           this.checkedKeys = props._treeNodesStates.checkedKeys;
         } else {
-          (function () {
-            var checkedKeys = _this6.state.checkedKeys;
-            var checkKeys = void 0;
-            if (!props.loadData && _this6.checkKeys && _this6._checkedKeys && (0, _util.arraysEqual)(_this6._checkedKeys, checkedKeys)) {
-              // if checkedKeys the same as _checkedKeys from onCheck, use _checkedKeys.
-              checkKeys = _this6.checkKeys;
-            } else {
-              (function () {
-                var checkedPositions = [];
-                _this6.treeNodesStates = {};
-                (0, _util.loopAllChildren)(props.children, function (item, index, pos, keyOrPos, siblingPosition) {
-                  _this6.treeNodesStates[pos] = {
-                    node: item,
-                    key: keyOrPos,
-                    checked: false,
-                    halfChecked: false,
-                    siblingPosition: siblingPosition
-                  };
-                  if (checkedKeys.indexOf(keyOrPos) !== -1) {
-                    _this6.treeNodesStates[pos].checked = true;
-                    checkedPositions.push(pos);
-                  }
-                });
-                // if the parent node's key exists, it all children node will be checked
-                (0, _util.handleCheckState)(_this6.treeNodesStates, (0, _util.filterParentPosition)(checkedPositions), true);
-                checkKeys = (0, _util.getCheck)(_this6.treeNodesStates);
-              })();
-            }
-            _this6.halfCheckedKeys = checkKeys.halfCheckedKeys;
-            _this6.checkedKeys = checkKeys.checkedKeys;
-          })();
+          var checkedKeys = this.state.checkedKeys;
+          var checkKeys = void 0;
+          if (!props.loadData && this.checkKeys && this._checkedKeys && (0, _util.arraysEqual)(this._checkedKeys, checkedKeys)) {
+            // if checkedKeys the same as _checkedKeys from onCheck, use _checkedKeys.
+            checkKeys = this.checkKeys;
+          } else {
+            var checkedPositions = [];
+            this.treeNodesStates = {};
+            (0, _util.loopAllChildren)(props.children, function (item, index, pos, keyOrPos, siblingPosition) {
+              _this6.treeNodesStates[pos] = {
+                node: item,
+                key: keyOrPos,
+                checked: false,
+                halfChecked: false,
+                siblingPosition: siblingPosition
+              };
+              if (checkedKeys.indexOf(keyOrPos) !== -1) {
+                _this6.treeNodesStates[pos].checked = true;
+                checkedPositions.push(pos);
+              }
+            });
+            // if the parent node's key exists, it all children node will be checked
+            (0, _util.handleCheckState)(this.treeNodesStates, (0, _util.filterParentPosition)(checkedPositions), true);
+            checkKeys = (0, _util.getCheck)(this.treeNodesStates);
+          }
+          this.halfCheckedKeys = checkKeys.halfCheckedKeys;
+          this.checkedKeys = checkKeys.checkedKeys;
         }
       }
 

--- a/lib/Tree.js
+++ b/lib/Tree.js
@@ -40,6 +40,10 @@ var _inherits2 = require('babel-runtime/helpers/inherits');
 
 var _inherits3 = _interopRequireDefault(_inherits2);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -52,8 +56,8 @@ var _util = require('./util');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var DRAG_EXPAND_DELAY = 500; /* eslint no-underscore-dangle: "off" */
-
+/* eslint no-underscore-dangle: "off" */
+var DRAG_EXPAND_DELAY = 500;
 var DROPPED_NODE_CLASS_NAME_DELAY = 1200;
 var DROP_GAP_SIZE = 2;
 
@@ -644,9 +648,7 @@ var Tree = function (_React$Component) {
 
       // expand
       if (val.expand && expandedKeys.indexOf(key) === -1) {
-        expandedKeys = expandedKeys.concat([key]);
-        this.props.onExpand(expandedKeys, { node: treeNode });
-        return expandedKeys;
+        return expandedKeys.concat([key]);
       }
 
       return null;
@@ -798,44 +800,44 @@ var Tree = function (_React$Component) {
 }(_react2.default.Component);
 
 Tree.propTypes = {
-  droppedNodeClassNameDelay: _react.PropTypes.number,
-  prefixCls: _react.PropTypes.string,
-  children: _react.PropTypes.any,
-  showLine: _react.PropTypes.bool,
-  showIcon: _react.PropTypes.bool,
-  selectable: _react.PropTypes.bool,
-  multiple: _react.PropTypes.bool,
-  checkable: _react.PropTypes.oneOfType([_react.PropTypes.bool, _react.PropTypes.node]),
-  _treeNodesStates: _react.PropTypes.object,
-  checkStrictly: _react.PropTypes.bool,
-  draggable: _react.PropTypes.bool,
-  autoExpandParent: _react.PropTypes.bool,
-  defaultExpandAll: _react.PropTypes.bool,
-  defaultExpandedKeys: _react.PropTypes.arrayOf(_react.PropTypes.string),
-  expandedKeys: _react.PropTypes.arrayOf(_react.PropTypes.string),
-  defaultCheckedKeys: _react.PropTypes.arrayOf(_react.PropTypes.string),
-  checkedKeys: _react.PropTypes.oneOfType([_react.PropTypes.arrayOf(_react.PropTypes.string), _react.PropTypes.object]),
-  defaultSelectedKeys: _react.PropTypes.arrayOf(_react.PropTypes.string),
-  selectedKeys: _react.PropTypes.arrayOf(_react.PropTypes.string),
-  onExpand: _react.PropTypes.func,
-  onCheck: _react.PropTypes.func,
-  onSelect: _react.PropTypes.func,
-  loadData: _react.PropTypes.func,
-  onMouseEnter: _react.PropTypes.func,
-  onMouseLeave: _react.PropTypes.func,
-  onRightClick: _react.PropTypes.func,
-  onDragStart: _react.PropTypes.func,
-  onDragEnd: _react.PropTypes.func,
-  onDragEnter: _react.PropTypes.func,
-  onDragOver: _react.PropTypes.func,
-  onDragLeave: _react.PropTypes.func,
-  onDrop: _react.PropTypes.func,
-  filterTreeNode: _react.PropTypes.func,
-  openTransitionName: _react.PropTypes.string,
-  openAnimation: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.object]),
-  dragExpandDelay: _react.PropTypes.number,
-  dropGapSize: _react.PropTypes.number,
-  externalDragMode: _react.PropTypes.object
+  droppedNodeClassNameDelay: _propTypes2.default.number,
+  prefixCls: _propTypes2.default.string,
+  children: _propTypes2.default.any,
+  showLine: _propTypes2.default.bool,
+  showIcon: _propTypes2.default.bool,
+  selectable: _propTypes2.default.bool,
+  multiple: _propTypes2.default.bool,
+  checkable: _propTypes2.default.oneOfType([_propTypes2.default.bool, _propTypes2.default.node]),
+  _treeNodesStates: _propTypes2.default.object,
+  checkStrictly: _propTypes2.default.bool,
+  draggable: _propTypes2.default.bool,
+  autoExpandParent: _propTypes2.default.bool,
+  defaultExpandAll: _propTypes2.default.bool,
+  defaultExpandedKeys: _propTypes2.default.arrayOf(_propTypes2.default.string),
+  expandedKeys: _propTypes2.default.arrayOf(_propTypes2.default.string),
+  defaultCheckedKeys: _propTypes2.default.arrayOf(_propTypes2.default.string),
+  checkedKeys: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.string), _propTypes2.default.object]),
+  defaultSelectedKeys: _propTypes2.default.arrayOf(_propTypes2.default.string),
+  selectedKeys: _propTypes2.default.arrayOf(_propTypes2.default.string),
+  onExpand: _propTypes2.default.func,
+  onCheck: _propTypes2.default.func,
+  onSelect: _propTypes2.default.func,
+  loadData: _propTypes2.default.func,
+  onMouseEnter: _propTypes2.default.func,
+  onMouseLeave: _propTypes2.default.func,
+  onRightClick: _propTypes2.default.func,
+  onDragStart: _propTypes2.default.func,
+  onDragEnd: _propTypes2.default.func,
+  onDragEnter: _propTypes2.default.func,
+  onDragOver: _propTypes2.default.func,
+  onDragLeave: _propTypes2.default.func,
+  onDrop: _propTypes2.default.func,
+  filterTreeNode: _propTypes2.default.func,
+  openTransitionName: _propTypes2.default.string,
+  openAnimation: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]),
+  dragExpandDelay: _propTypes2.default.number,
+  dropGapSize: _propTypes2.default.number,
+  externalDragMode: _propTypes2.default.object
 };
 
 Tree.defaultProps = {

--- a/lib/TreeNode.js
+++ b/lib/TreeNode.js
@@ -66,7 +66,7 @@ var TreeNode = function (_React$Component) {
   function TreeNode(props) {
     (0, _classCallCheck3.default)(this, TreeNode);
 
-    var _this = (0, _possibleConstructorReturn3.default)(this, (0, _getPrototypeOf2.default)(TreeNode).call(this, props));
+    var _this = (0, _possibleConstructorReturn3.default)(this, (TreeNode.__proto__ || (0, _getPrototypeOf2.default)(TreeNode)).call(this, props));
 
     ['onExpand', 'onCheck', 'onContextMenu', 'onMouseEnter', 'onMouseLeave', 'onDragStart', 'onDragEnd', 'onDragEnter', 'onDragOver', 'onDragLeave', 'onDrop'].forEach(function (m) {
       return _this[m] = _this[m].bind(_this);
@@ -203,17 +203,15 @@ var TreeNode = function (_React$Component) {
 
       var callbackPromise = this.props.root.onExpand(this);
       if (callbackPromise && (typeof callbackPromise === 'undefined' ? 'undefined' : (0, _typeof3.default)(callbackPromise)) === 'object') {
-        (function () {
-          var setLoading = function setLoading(dataLoading) {
-            _this2.setState({ dataLoading: dataLoading });
-          };
-          setLoading(true);
-          callbackPromise.then(function () {
-            setLoading(false);
-          }, function () {
-            setLoading(false);
-          });
-        })();
+        var setLoading = function setLoading(dataLoading) {
+          _this2.setState({ dataLoading: dataLoading });
+        };
+        setLoading(true);
+        callbackPromise.then(function () {
+          setLoading(false);
+        }, function () {
+          setLoading(false);
+        });
       }
     }
 

--- a/lib/TreeNode.js
+++ b/lib/TreeNode.js
@@ -48,6 +48,10 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _rcAnimate = require('rc-animate');
 
 var _rcAnimate2 = _interopRequireDefault(_rcAnimate);
@@ -548,16 +552,16 @@ var TreeNode = function (_React$Component) {
 TreeNode.isTreeNode = 1;
 
 TreeNode.propTypes = {
-  prefixCls: _react.PropTypes.string,
-  disabled: _react.PropTypes.bool,
-  disableCheckbox: _react.PropTypes.bool,
-  expanded: _react.PropTypes.bool,
-  isLeaf: _react.PropTypes.bool,
-  root: _react.PropTypes.object,
-  onSelect: _react.PropTypes.func,
-  items: _react.PropTypes.node,
-  padding: _react.PropTypes.number,
-  basePadding: _react.PropTypes.number
+  prefixCls: _propTypes2.default.string,
+  disabled: _propTypes2.default.bool,
+  disableCheckbox: _propTypes2.default.bool,
+  expanded: _propTypes2.default.bool,
+  isLeaf: _propTypes2.default.bool,
+  root: _propTypes2.default.object,
+  onSelect: _propTypes2.default.func,
+  items: _propTypes2.default.node,
+  padding: _propTypes2.default.number,
+  basePadding: _propTypes2.default.number
 };
 
 TreeNode.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draggable-react-tree-component",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "A (trying to be) lightweight tree component for react.",
   "keywords": [
     "draggable",
@@ -68,8 +68,8 @@
     "pre-commit": "^1.1.3",
     "raw-loader": "^0.5.1",
     "rc-animate": "2.x",
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "rimraf": "^2.5.4",
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draggable-react-tree-component",
-  "version": "1.0.16",
+  "version": "1.0.18",
   "description": "A (trying to be) lightweight tree component for react.",
   "keywords": [
     "draggable",

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -47,8 +47,8 @@ class Tree extends React.Component {
     const st = {}
 
     if (nextProps.externalDragMode) {
-      this.dragNodesKeys = nextProps.externalDragMode.externalDragNodeKeys;
-      this.dragNode = nextProps.externalDragMode.externalDragNode;
+      this.dragNodesKeys = nextProps.externalDragMode.externalDragNodeKeys
+      this.dragNode = nextProps.externalDragMode.externalDragNode
     }
 
     if (expandedKeys) {
@@ -586,7 +586,7 @@ class Tree extends React.Component {
   updateExpandedKeys(treeNode, val) {
 
     const key = treeNode.props.eventKey
-    const expandedKeys = this.state.expandedKeys
+    let expandedKeys = this.state.expandedKeys
     const expandedIndex = expandedKeys.indexOf(key)
     let exKeys
 
@@ -599,7 +599,9 @@ class Tree extends React.Component {
 
     // expand
     if (val.expand && expandedKeys.indexOf(key) === -1) {
-      return expandedKeys.concat([key])
+      expandedKeys = expandedKeys.concat([key])
+      this.props.onExpand(expandedKeys, { node: treeNode })
+      return expandedKeys
     }
 
     return null
@@ -792,6 +794,7 @@ Tree.propTypes = {
   openAnimation: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   dragExpandDelay: PropTypes.number,
   dropGapSize: PropTypes.number,
+  externalDragMode: PropTypes.object,
 }
 
 Tree.defaultProps = {

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -1,5 +1,7 @@
 /* eslint no-underscore-dangle: "off" */
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames'
 import {
   loopAllChildren,
@@ -586,7 +588,7 @@ class Tree extends React.Component {
   updateExpandedKeys(treeNode, val) {
 
     const key = treeNode.props.eventKey
-    let expandedKeys = this.state.expandedKeys
+    const expandedKeys = this.state.expandedKeys
     const expandedIndex = expandedKeys.indexOf(key)
     let exKeys
 
@@ -599,9 +601,7 @@ class Tree extends React.Component {
 
     // expand
     if (val.expand && expandedKeys.indexOf(key) === -1) {
-      expandedKeys = expandedKeys.concat([key])
-      this.props.onExpand(expandedKeys, { node: treeNode })
-      return expandedKeys
+      return expandedKeys.concat([key])
     }
 
     return null

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -247,7 +247,12 @@ class Tree extends React.Component {
 
     // restore expanded keys
     if ('expandedKeys' in this.props) {
-      res.rawExpandedKeys = [...this._rawExpandedKeys] || [...this.state.expandedKeys]
+      if (this._rawExpandedKeys) {
+        res.rawExpandedKeys = [...this._rawExpandedKeys]
+      }
+      else {
+        res.rawExpandedKeys = [...this.state.expandedKeys]
+      }
     }
 
     this.props.onDrop(res)

--- a/src/TreeNode.js
+++ b/src/TreeNode.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react';
 import classNames from 'classnames'
+import PropTypes from 'prop-types';
 import Animate from 'rc-animate'
 import Spinner from './Spinner'
 


### PR DESCRIPTION
When dragging between different trees there is a case when `this._rawExpandendKeys` is not defined. In these cases the state holds the correct data.